### PR TITLE
fix: Eye-pleasing translation changes

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="about">"около"</string>
-    <string name="activate">"активировать"</string>
+    <string name="about">"О приложении"</string>
+    <string name="activate">"Активировать"</string>
     <string name="app_name">"GIF Живые Обои"</string>
-    <string name="change_color">"сменить цвет"</string>
-    <string name="change_scale">"изменить масштаб"</string>
-    <string name="clear_gif">"очистить GIF"</string>
-    <string name="click_the_open_gif_button">"нажмите кнопку Открыть GIF"</string>
+    <string name="change_color">"Сменить цвет"</string>
+    <string name="change_scale">"Изменить масштаб"</string>
+    <string name="clear_gif">"Очистить GIF"</string>
+    <string name="click_the_open_gif_button">"Нажмите кнопку Открыть GIF"</string>
 
     <!-- Have an error code? -->
-    <string name="error_wallpaper_chooser">"ошибка выбора обоев"</string>
-    <string name="loading">"загрузка"</string>
-    <string name="open_app">"открыть приложение"</string>
-    <string name="open_gif">"открыть GIF"</string>
-    <string name="pick_a_color">"выбери цвет"</string>
-    <string name="privacy">"конфиденциальность"</string>
-    <string name="rotate">"вращять"</string>
+    <string name="error_wallpaper_chooser">"Ошибка выбора обоев"</string>
+    <string name="loading">"Загрузка"</string>
+    <string name="open_app">"Откройте приложение"</string>
+    <string name="open_gif">"Открыть GIF"</string>
+    <string name="pick_a_color">"Выбор цвета"</string>
+    <string name="privacy">"Конфиденциальность"</string>
+    <string name="rotate">"Вращать"</string>
 </resources>


### PR DESCRIPTION
Grammar mistake: "Rotate" == "Вращать".
Not "Около". Correct: "Информация" or "О приложении".