### PR TITLE
fix: Fix crash in lifecycle affecting Vivo v21

### DIFF
--- a/app/src/main/java/net/redwarp/gifwallpaper/EngineLifecycleDispatcher.kt
+++ b/app/src/main/java/net/redwarp/gifwallpaper/EngineLifecycleDispatcher.kt
@@ -15,6 +15,7 @@
  */
 package net.redwarp.gifwallpaper
 
+import android.annotation.SuppressLint
 import android.os.Handler
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -25,7 +26,8 @@ import androidx.lifecycle.LifecycleRegistry
  * Adapted from [androidx.lifecycle.ServiceLifecycleDispatcher].
  */
 class EngineLifecycleDispatcher(provider: LifecycleOwner) {
-    private val registry: LifecycleRegistry = LifecycleRegistry(provider)
+    @SuppressLint("VisibleForTests")
+    private val registry: LifecycleRegistry = LifecycleRegistry.createUnsafe(provider)
     @Suppress("DEPRECATION")
     private val handler: Handler = Handler()
     private var lastDispatchRunnable: DispatchRunnable? = null

--- a/app/src/main/java/net/redwarp/gifwallpaper/EngineLifecycleDispatcher.kt
+++ b/app/src/main/java/net/redwarp/gifwallpaper/EngineLifecycleDispatcher.kt
@@ -1,0 +1,71 @@
+/* Copyright 2020 Benoit Vermont
+ * Copyright 2020 GifWallpaper Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.redwarp.gifwallpaper
+
+import android.os.Handler
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+
+/**
+ * Helper class to dispatch lifecycle events for our wallpaper engine.
+ * Adapted from [androidx.lifecycle.ServiceLifecycleDispatcher].
+ */
+class EngineLifecycleDispatcher(provider: LifecycleOwner) {
+    private val registry: LifecycleRegistry = LifecycleRegistry(provider)
+    @Suppress("DEPRECATION")
+    private val handler: Handler = Handler()
+    private var lastDispatchRunnable: DispatchRunnable? = null
+
+    private fun postDispatchRunnable(event: Lifecycle.Event) {
+        lastDispatchRunnable?.run()
+        lastDispatchRunnable = DispatchRunnable(registry, event).also {
+            handler.postAtFrontOfQueue(it)
+        }
+    }
+
+    fun onResume() {
+        postDispatchRunnable(Lifecycle.Event.ON_RESUME)
+    }
+
+    fun onCreate() {
+        postDispatchRunnable(Lifecycle.Event.ON_CREATE)
+    }
+
+    fun onStop() {
+        postDispatchRunnable(Lifecycle.Event.ON_STOP)
+    }
+
+    fun onDestroy() {
+        postDispatchRunnable(Lifecycle.Event.ON_DESTROY)
+    }
+
+    val lifecycle: Lifecycle
+        get() = registry
+
+    internal class DispatchRunnable(
+        private val registry: LifecycleRegistry,
+        private val event: Lifecycle.Event
+    ) : Runnable {
+        private var wasExecuted = false
+        override fun run() {
+            if (!wasExecuted) {
+                registry.handleLifecycleEvent(event)
+                wasExecuted = true
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/redwarp/gifwallpaper/GifWallpaperService.kt
+++ b/app/src/main/java/net/redwarp/gifwallpaper/GifWallpaperService.kt
@@ -55,6 +55,10 @@ class GifWallpaperService : WallpaperService(), LifecycleOwner {
         dispatcher.onDestroy()
     }
 
+    override fun getLifecycle(): Lifecycle {
+        return dispatcher.lifecycle
+    }
+
     inner class GifEngine : Engine() {
         private var surfaceDrawableRenderer: SurfaceDrawableRenderer? = null
 
@@ -143,9 +147,5 @@ class GifWallpaperService : WallpaperService(), LifecycleOwner {
             bitmap.recycle()
             return wallpaperColors
         }
-    }
-
-    override fun getLifecycle(): Lifecycle {
-        return dispatcher.lifecycle
     }
 }


### PR DESCRIPTION
It seems that in android 12, the wallpaper service launch wallpaper service and engine a bit differently, and it might not run on the main thread. It cause the lifecycle dispatcher to complain, because it's normal use case is in an activity.
This fixes it by using the unsafe version of the dispatcher, that will ignore the thread.

Fixes #203 