### PR TITLE
feat: Allow GIF to play only once

### DIFF
--- a/app/src/androidTest/java/net/redwarp/gifwallpaper/util/FakeAppSettings.kt
+++ b/app/src/androidTest/java/net/redwarp/gifwallpaper/util/FakeAppSettings.kt
@@ -24,9 +24,13 @@ class FakeAppSettings : AppSettings {
         get() = flowOf(true)
     override val thermalThrottleSettingFlow: Flow<Boolean>
         get() = flowOf(false)
+    override val infiniteLoopSettingFlow: Flow<Boolean>
+        get() = flowOf(false)
     override val isThermalThrottleSupported: Boolean = true
 
     override suspend fun setPowerSaving(enabled: Boolean) = Unit
 
     override suspend fun setThermalThrottle(enabled: Boolean) = Unit
+
+    override suspend fun setInfiniteLoop(enabled: Boolean) = Unit
 }

--- a/app/src/main/java/net/redwarp/gifwallpaper/AppSettings.kt
+++ b/app/src/main/java/net/redwarp/gifwallpaper/AppSettings.kt
@@ -29,14 +29,17 @@ import kotlinx.coroutines.flow.map
 interface AppSettings {
     val powerSavingSettingFlow: Flow<Boolean>
     val thermalThrottleSettingFlow: Flow<Boolean>
+    val infiniteLoopSettingFlow: Flow<Boolean>
     val isThermalThrottleSupported: Boolean
     suspend fun setPowerSaving(enabled: Boolean)
     suspend fun setThermalThrottle(enabled: Boolean)
+    suspend fun setInfiniteLoop(enabled: Boolean)
 }
 
 class DataStoreAppSettings(private val context: Context, ioScope: CoroutineScope) : AppSettings {
     private val powerSavingKey = booleanPreferencesKey("power_saving")
     private val thermalThrottleKey = booleanPreferencesKey("thermal_throttle")
+    private val infiniteLoopKey = booleanPreferencesKey("infinite_loop")
     private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
         "app_settings",
         scope = ioScope,
@@ -52,6 +55,9 @@ class DataStoreAppSettings(private val context: Context, ioScope: CoroutineScope
         }
     override val isThermalThrottleSupported: Boolean =
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+    override val infiniteLoopSettingFlow: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[infiniteLoopKey] ?: context.resources.getBoolean(R.bool.infinite_loop_enabled)
+    }
 
     override suspend fun setPowerSaving(enabled: Boolean) {
         context.dataStore.edit { preferences ->
@@ -62,6 +68,12 @@ class DataStoreAppSettings(private val context: Context, ioScope: CoroutineScope
     override suspend fun setThermalThrottle(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[thermalThrottleKey] = enabled
+        }
+    }
+
+    override suspend fun setInfiniteLoop(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[infiniteLoopKey] = enabled
         }
     }
 }

--- a/app/src/main/java/net/redwarp/gifwallpaper/data/FlowBasedModel.kt
+++ b/app/src/main/java/net/redwarp/gifwallpaper/data/FlowBasedModel.kt
@@ -90,6 +90,7 @@ class FlowBasedModel(
 
         !(powerSavingOn || thermalThrottlingOn)
     }
+    val infiniteLoopFlow: Flow<Boolean> = appSettings.infiniteLoopSettingFlow
 
     @OptIn(FlowPreview::class)
     val updateFlow: Flow<Unit>

--- a/app/src/main/java/net/redwarp/gifwallpaper/renderer/DrawableMapper.kt
+++ b/app/src/main/java/net/redwarp/gifwallpaper/renderer/DrawableMapper.kt
@@ -128,7 +128,11 @@ class DrawableMapper private constructor(
                         val gif = withContext(Dispatchers.IO) {
                             GifDrawable(status.gifDescriptor)
                         }
-                        gif.loopCount = LoopCount.Infinite
+                        if (flowBasedModel.infiniteLoopFlow.first()) {
+                            gif.loopCount = LoopCount.Infinite
+                        } else {
+                            gif.loopCount = LoopCount.Fixed(1)
+                        }
                         val shouldPlay = !isService || flowBasedModel.shouldPlay.first()
                         val scaleType = flowBasedModel.scaleTypeFlow.first()
                         val rotation = flowBasedModel.rotationFlow.first()

--- a/app/src/main/java/net/redwarp/gifwallpaper/ui/SettingsComposable.kt
+++ b/app/src/main/java/net/redwarp/gifwallpaper/ui/SettingsComposable.kt
@@ -91,6 +91,7 @@ fun SettingUi(navController: NavController, appSettings: AppSettings) {
         ) {
             val isPowerSaving by appSettings.powerSavingSettingFlow.collectAsState(initial = false)
             val isThermalThrottle by appSettings.thermalThrottleSettingFlow.collectAsState(initial = false)
+            val isInfiniteLoop by appSettings.infiniteLoopSettingFlow.collectAsState(initial = true)
             val scope = rememberCoroutineScope()
 
             Setting(
@@ -116,6 +117,17 @@ fun SettingUi(navController: NavController, appSettings: AppSettings) {
                     },
                 )
             }
+
+            Setting(
+                title = stringResource(id = R.string.loop_gif),
+                summary = stringResource(id = R.string.inifinitely_loop_gif),
+                checked = { isInfiniteLoop },
+                onCheckedChanged = { enabled ->
+                    scope.launch {
+                        appSettings.setInfiniteLoop(enabled)
+                    }
+                },
+            )
         }
     }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -23,4 +23,6 @@
   <string name="rotate">"Rotation"</string>
   <string name="settings">"Paramètres"</string>
   <string name="thermal_throttle">"Atténuation thermique"</string>
+  <string name="loop_gif">"Lecture en boucle"</string>
+  <string name="inifinitely_loop_gif">"Répéter le GIF à l'infini"</string>
 </resources>

--- a/app/src/main/res/values/preferences_default.xml
+++ b/app/src/main/res/values/preferences_default.xml
@@ -2,4 +2,5 @@
 <resources>
     <bool name="power_saving_enabled">false</bool>
     <bool name="thermal_throttle_enabled">false</bool>
+    <bool name="infinite_loop_enabled">true</bool>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,6 @@
   <string name="rotate">"Rotate"</string>
   <string name="settings">"Settings"</string>
   <string name="thermal_throttle">"Thermal Mitigation"</string>
+  <string name="loop_gif">"Loop playback"</string>
+  <string name="inifinitely_loop_gif">"Repeat GIF infinitely"</string>
 </resources>


### PR DESCRIPTION
Adds a setting that changes the default LoopCount.Infinite for a fixed one time playback.

Allows to use a GIF that doesn't loop correctly or is made to stop after one loop.
Can also save battery life since the screen stops redrawing when the GIF stops moving.